### PR TITLE
Change project name to 'Spark Fhir server'

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 |![Release](https://github.com/FirelyTeam/spark/actions/workflows/nuget_deploy.yml/badge.svg)|![Release](https://github.com/FirelyTeam/spark/actions/workflows/nuget_deploy.yml/badge.svg)|![Release](https://github.com/FirelyTeam/spark/actions/workflows/nuget_deploy.yml/badge.svg)
 |![Docker Release](https://github.com/FirelyTeam/spark/actions/workflows/docker_image_linux.yml/badge.svg)|![Docker Release](https://github.com/FirelyTeam/spark/actions/workflows/docker_image_linux.yml/badge.svg)|![Docker Release](https://github.com/FirelyTeam/spark/actions/workflows/docker_image_linux.yml/badge.svg)
 
-Spark
+Spark Fhir server
 =====
 
 Spark is an open-source FHIR server developed in C#, initially built by Firely. Further development 


### PR DESCRIPTION
Updated the project name in the README to 'Spark Fhir server'.